### PR TITLE
Implements a `follow` mode

### DIFF
--- a/p2000.cfg
+++ b/p2000.cfg
@@ -1,7 +1,6 @@
 # configuration file for p2000
 [global]
 baseurl = http://p2000mobiel.nl/
-default = 40/geheel-nederland.html
 refresh = false
 refreshtime = 30
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 bs4
+progress


### PR DESCRIPTION
This commit adds a 'pretty print' function for a `p2000data['p2000']` list
element (i.e. a JSON object). It adds a 'follow' mode, where new messages from
the selected region automatically appear after the last message. This also
means the initial order of the messages is reversed, to make sure the message
displayed last is the most recent one (without follow mode, the most recent
message is shown on top). To show the user that they have to wait for
`refreshtime` seconds, a progress bar is shown below the last (most recent)
message. After new messages arrive, this progress bar "disappears" from its
spot and reappears after the last message was printed.